### PR TITLE
add twitch train/raid button and functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,15 +6,20 @@ import datetime
 import redis
 
 from flask import Flask, jsonify, send_from_directory
+from flask_cors import CORS
 app = Flask(__name__, static_url_path='', static_folder='static')
+CORS(app)
 main_redis = redis.Redis(decode_responses=True, db=0)
 stats_redis = redis.Redis(decode_responses=True, db=1)
 
 
-def getStreams(count = 1):
+def getStreams(count = 1, trainId=None):
     results = []
     for i in range(int(count)):
-        key = main_redis.randomkey()
+        if trainId is None:
+            key = main_redis.randomkey()
+        else:
+            key = main_redis.keys(pattern='*{}*'.format(trainId))[0]
 
         if not key:
             return results
@@ -37,6 +42,23 @@ def get_stream():
     if streams:
         return streams[0]
     return '{}'
+
+@app.route('/streamtrainId/<trainId>')
+def get_stream_train(trainId):
+    print("Trainid: ", trainId)
+    streams = getStreams(trainId=trainId)
+    if streams:
+        return streams[0]
+    return '{}'
+
+@app.route('/streamtrain')
+def get_stream_trainId():
+    key = main_redis.randomkey()
+    stream = json.loads(key)
+    trainId = stream['id']
+
+    return trainId
+
 
 @app.route('/streams', defaults={'count': 20})
 @app.route('/streams/<count>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ redis==3.5.3              # via -r requirements.in
 requests==2.24.0          # via -r requirements.in
 urllib3==1.25.11          # via requests
 werkzeug==1.0.1           # via flask
-
+flask-cors==3.0.9		  # via flask-cors
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,9 @@
         <h1>nobody.live</h1>
         <p>streams with nobody watching</p>
       </div>
+      <div class="refresh2">
+        <button id="join-train-button" disabled>please wait...</button>
+      </div>
       <div class="refresh">
         <button id="new-streamer-button" disabled>please wait...</button>
       </div>
@@ -56,7 +59,8 @@
     <script src="https://embed.twitch.tv/embed/v1.js"></script>
     <script type="text/javascript">
       let numberOfThumbnailsToFetch = 12;
-      let server = 'https://nobody.live';
+      let server =  window.location.hostname === '127.0.0.1' ? 'http://localhost:5000':'https://nobody.live';
+      let trainId = NaN
 
       function displayStream(stream) {
         // clear and rerender the embed div
@@ -88,14 +92,63 @@
           return a.outerHTML;
         }).join(', ');
       }
+      // execute find trainId every 60 seconds
+      var intervalId = window.setInterval(fetchTrainId, 60000)
+      var foundTrainId = false
+      let changingIn = 60
+      function fetchTrainId() {
+        fetch(`${server}/streamtrain`).then(response => response.json())
+          .then(newTrainId => {
+            console.log(newTrainId)
+            trainId = newTrainId;
+            foundTrainId = true;
+            changingIn = 60;
+          }).catch((error) => {
+            console.eror('Error:', error)
+          });
+      }
+      fetchTrainId()
 
+      // join train button show countdown
+      var intervalId = window.setInterval(setChangingIn, 1000)
+      function setChangingIn() {
+        document.getElementById('join-train-button').disabled = false;
+        document.getElementById('join-train-button').innerText = 'join twitch train! new streamer in ' + changingIn + ' seconds';
+        if (changingIn > 0) {
+          changingIn = changingIn - 1;
+        }
+      }
+
+      async function fetchAndRenderStreamTrain() {
+        document.getElementById('join-train-button').disabled = true;
+        document.getElementById('join-train-button').innerText = 'please wait...';
+        setTimeout(() => {
+          document.getElementById('join-train-button').disabled = false;
+        }, 4000);
+
+        fetch(`${server}/streamtrainId/${trainId}`).then(response => response.json())
+          .then(stream => {
+            console.log('Got stream:', stream);
+
+            if (Object.keys(stream).length === 0) {
+              alert("Uh oh! There's been an issue retrieving a stream. Either there are no streams (unlikely) or something is broken.")
+              return
+            }
+
+            displayStream(stream);
+          }).catch((error) => {
+            console.error('Error:', error);
+          });
+
+
+      }
       async function fetchAndRenderRandomStream() {
         // disable button to do some hacky rate limiting
         document.getElementById('new-streamer-button').disabled = true;
         document.getElementById('new-streamer-button').innerText = 'please wait...';
         setTimeout(() => {
           document.getElementById('new-streamer-button').disabled = false;
-          document.getElementById('new-streamer-button').innerText = 'new streamer';
+          document.getElementById('new-streamer-button').innerText = 'random streamer';
         }, 4000);
 
         fetch(`${server}/stream`).then(response => response.json())
@@ -155,6 +208,7 @@
 
       document.getElementById('new-streamer-button').addEventListener('click', fetchAndRenderRandomStream);
       document.getElementById('new-thumbnails').addEventListener('click', fetchAndRenderThumbnails);
+      document.getElementById('join-train-button').addEventListener('click', fetchAndRenderStreamTrain)
 
       // little treat for the readers :)
       document.addEventListener("keydown", event => {

--- a/static/styles.css
+++ b/static/styles.css
@@ -30,14 +30,18 @@ a,
 @media only screen and (min-width: 750px) {
   .grid-container {
     display: grid;
-    grid-template-columns: 80% 20%;
+    grid-template-columns: 33.33% 33.33% 33.33%;
     grid-template-rows: 1fr;
-    gap: 0px 0px;
-    grid-template-areas: "intro-text refresh";
+    grid-gap: 0px 10px;
+    grid-template-areas: "intro-text refresh2 refresh";
     height: 6vh;
   }
   .intro-text {
     grid-area: intro-text;
+  }
+  .refresh2 {
+    grid-area: refresh2;
+    align-self: center;
   }
   .refresh {
     grid-area: refresh;
@@ -62,6 +66,9 @@ a,
   #new-streamer-button {
     margin-top: 20px;
   }
+  #join-train-button {
+    margin-top: 20px;
+  }
 }
 
 #new-streamer-button {
@@ -77,8 +84,28 @@ a,
   cursor: pointer;
 }
 
+
 #new-streamer-button:disabled,
 #new-streamer-button[disabled] {
+  background-color: #efefef;
+  cursor: wait;
+}
+
+#join-train-button {
+  background-color: #008a07;
+  border: none;
+  color: white;
+  padding: 10px 5px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  width: 100%;
+  cursor: pointer;
+}
+
+#join-train-button:disabled,
+#join-train-button[disabled] {
   background-color: #efefef;
   cursor: wait;
 }


### PR DESCRIPTION
Heya jkingsman. I found your website off of the reddit post and was super interested in learning from it. So I did my best to make a "twitch train" or "twitch raid" button or whatever you'd want to call it: where users of the site can click the button and all join _the same_ random twitch stream with 0 viewers. 

To do this, in `index.html`, every 60 seconds a GET request is made to get the id of one random 0 viewer stream from the `main_redis`. This id is then passed into the GET request for whenever the "twitch train" button is pressed so that any user that pushes the button will be shown the same stream (until the next 60 seconds are up and a new id is grabbed).

Also I had to do `from flask_cors import CORS` and `CORS(app)` in `app.py` to get the api to work on my local machine. I'm not sure if this is necessary for the production server or really what the consequences of this are if this were to be merged to the actual server.

One thing I still don't like is the formatting of the buttons. Too much text in the "twitch train" button makes it wrap-around when the window is skinny and not look as nice. dang it. Another thing I'm worried about is if `scanner.py` clears the redis during a 60 second cycle so the GET request can't find the specific id it had saved. Although after messing around with it for a good amount of time I never experienced the pop up alert of "Uh oh! There's been an issue retrieving a stream..." when pressing the twitch train button.

This is my first pull request so please yell at me if I'm doing this wrong. Super cool website, it proved very distracting while trying to get this idea to work haha.